### PR TITLE
バックエンド：睡眠推定処理

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,12 @@
     "source.removeUnusedVariables",
     "source.convertImportFormat"
   ],
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportUnknownArgumentType": "none",
+    "reportUnknownVariableType": "none",
+    "reportUnknownMemberType": "none",
+    "reportAttributeAccessIssue": "none"
+  },
   "ruff.interpreter": ["${workspaceFolder}/backend/.venv/bin/python"],
   "ruff.path": ["${workspaceFolder}/backend/.venv/bin/ruff"],
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,9 @@ SAMPLE_DATA_DIR=${DATASTORE_DIR}/sample_data
 # model を格納しているディレクトリパス
 MODELS_DIR=${DATASTORE_DIR}/models
 
+# 統計データを格納しているディレクトリパス
+STATISTICAL_DATA_DIR=${DATASTORE_DIR}/statistical_data
+
 # apiプレフィックス
 API_V1_PREFIX=/api/v1
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,7 @@
 
 # Backend specific data files
 sample_data/
+statistical_data/
 models/
 uploads/
 data/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 from fastapi import FastAPI
 
 from src.core.load_env import envs
@@ -5,6 +8,9 @@ from src.routers import estimate_sleep, extract_steps
 
 app = FastAPI()
 
+# デバッグ時は print を無効化しない
+if not envs.IS_DEBUG:
+    sys.stdout = open(os.devnull, "w")
 
 app.include_router(extract_steps.router, prefix=envs.API_V1_PREFIX)
 app.include_router(estimate_sleep.router, prefix=envs.API_V1_PREFIX)

--- a/backend/src/core/constants.py
+++ b/backend/src/core/constants.py
@@ -15,6 +15,9 @@ STEP_COUNT_CSV_FILENAME = "step_count_data.csv"
 SLEEP_ANALYSIS_CSV_FILENAME = "sleep_analysis_data.csv"
 """デバッグ用に保存する睡眠データのCSVファイル名"""
 
+CORRECTION_VALUE_JSON_FILENAME = "correction_value.json"
+"""アンケートごとの時間補正値のJSONファイル名"""
+
 FEATURE_TIME_RANGE = 0, 12  # (0時~12時)
 """特徴量となるデータの時間範囲(1時間ごと)"""
 

--- a/backend/src/core/constants.py
+++ b/backend/src/core/constants.py
@@ -15,5 +15,11 @@ STEP_COUNT_CSV_FILENAME = "step_count_data.csv"
 SLEEP_ANALYSIS_CSV_FILENAME = "sleep_analysis_data.csv"
 """デバッグ用に保存する睡眠データのCSVファイル名"""
 
-FEATURE_TIME_RANGE = 0, 12
-"""特徴量となるデータの時間範囲(0時~12時)"""
+FEATURE_TIME_RANGE = 0, 12  # (0時~12時)
+"""特徴量となるデータの時間範囲(1時間ごと)"""
+
+WEEKDAY_TIME_RANGE = ["3:00", "4:15", "12:00", "21:00"]
+"""平日の精査範囲"""
+
+HOLIDAY_TIME_RANGE = ["3:00", "4:45", "12:45", "20:45"]
+"""休日の精査範囲"""

--- a/backend/src/core/load_env.py
+++ b/backend/src/core/load_env.py
@@ -21,6 +21,9 @@ class Envs(BaseSettings):
     MODELS_DIR: str = Field(default="./datastore/models")
     """modelを格納しているディレクトリパス"""
 
+    STATISTICAL_DATA_DIR: str = Field(default="./datastore/statistical_data")
+    """統計データを格納しているディレクトリパス"""
+
     API_V1_PREFIX: str = Field(default="/api/v1")
     """APIの接頭辞"""
 

--- a/backend/src/routers/estimate_sleep.py
+++ b/backend/src/routers/estimate_sleep.py
@@ -2,7 +2,7 @@ import pandas as pd
 from fastapi import APIRouter
 from pandera.typing import DataFrame
 
-from src.schemas.estimate_sleep import EstimateSleepRequest
+from src.schemas.estimate_sleep import EstimateSleepRequest, EstimateSleepResponse
 from src.schemas.extract_steps import StepCountDFSchema
 from src.usecases.estimate_sleep.detection_late_night_usecase import detect_late_night
 from src.usecases.estimate_sleep.estimate_sleep_duration_usecase import (
@@ -60,11 +60,11 @@ def estimate_sleep(req: EstimateSleepRequest):
 
     # print(cluster_stats)
 
-    estimate_sleep_duration_from_step(
+    estimated_data = estimate_sleep_duration_from_step(
         estimate_going_out_df,
         late_night_list,
         answers.charging_before_bed_answer,
         answers.carrying_a_smartphone_answer,
     )
 
-    return
+    return EstimateSleepResponse(data=estimated_data)

--- a/backend/src/routers/estimate_sleep.py
+++ b/backend/src/routers/estimate_sleep.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/estimate-sleep", tags=["estimate-sleep"])
         },
     },
 )
-def estimate_sleep(req: EstimateSleepRequest):
+def estimate_sleep(req: EstimateSleepRequest) -> EstimateSleepResponse:
     """睡眠推定を受け付ける"""
 
     id = req.id

--- a/backend/src/routers/estimate_sleep.py
+++ b/backend/src/routers/estimate_sleep.py
@@ -5,6 +5,9 @@ from pandera.typing import DataFrame
 from src.schemas.estimate_sleep import EstimateSleepRequest
 from src.schemas.extract_steps import StepCountDFSchema
 from src.usecases.estimate_sleep.detection_late_night_usecase import detect_late_night
+from src.usecases.estimate_sleep.estimate_sleep_duration_usecase import (
+    estimate_sleep_duration_from_step,
+)
 from src.usecases.estimate_sleep.feature_of_late_night_usecase import (
     create_feature_value,
 )
@@ -43,7 +46,7 @@ def estimate_sleep(req: EstimateSleepRequest):
     )  # type: ignore
 
     # 外出検知のため1分あたりの歩数を計算しクラスタリングを行う
-    estimate_sleep_df, cluster_stats = step_clustering(step_count_df)
+    estimate_going_out_df, _cluster_stats = step_clustering(step_count_df)
 
     # 歩数データから夜更かしを推定するための特徴量を抽出
     feature = create_feature_value(step_count_df, answers.bedtime_answer)
@@ -51,10 +54,17 @@ def estimate_sleep(req: EstimateSleepRequest):
     # 特徴量から夜更かし検知を行う
     late_night_list = detect_late_night(feature)
 
-    print(late_night_list)
+    # print(late_night_list)
 
-    print(estimate_sleep_df)
+    # print(estimate_going_out_df)
 
-    print(cluster_stats)
+    # print(cluster_stats)
+
+    estimate_sleep_duration_from_step(
+        estimate_going_out_df,
+        late_night_list,
+        answers.charging_before_bed_answer,
+        answers.carrying_a_smartphone_answer,
+    )
 
     return

--- a/backend/src/schemas/estimate_sleep.py
+++ b/backend/src/schemas/estimate_sleep.py
@@ -151,3 +151,30 @@ class LateNightFeature(BaseModel):
 
     feature: List[DailyStats] = Field(description="特徴量")
     """特徴量"""
+
+
+class DailyEstimateSleep(BaseModel):
+    date: datetime = Field(
+        description="日付",
+        examples=["2025-11-01"],
+    )
+    """日付"""
+
+    bed_time: str = Field(description="推定した就寝時刻", examples=["03:00"])
+    """推定した就寝時刻"""
+
+    wake_time: str = Field(description="推定した起床時刻", examples=["09:28"])
+    """推定した起床時刻"""
+
+    is_default_time: List[bool] = Field(
+        description="デフォルトの時間を使ったかどうか [就寝時刻, 起床時刻]",
+        examples=[True, False],
+    )
+    """デフォルトの時間を使ったかどうか"""
+
+
+class EstimateSleepResponse(BaseModel):
+    data: List[DailyEstimateSleep] = Field(
+        description="推定された日々の就寝時刻と起床時刻"
+    )
+    """推定された日々の就寝時刻と起床時刻"""

--- a/backend/src/schemas/estimate_sleep.py
+++ b/backend/src/schemas/estimate_sleep.py
@@ -168,7 +168,7 @@ class DailyEstimateSleep(BaseModel):
 
     is_default_time: List[bool] = Field(
         description="デフォルトの時間を使ったかどうか [就寝時刻, 起床時刻]",
-        examples=[True, False],
+        examples=[[True, False]],
     )
     """デフォルトの時間を使ったかどうか"""
 

--- a/backend/src/schemas/estimate_sleep.py
+++ b/backend/src/schemas/estimate_sleep.py
@@ -96,7 +96,7 @@ class StepClusters(BaseModel):
     """クラスターのタプル（常に3つ固定: 低歩数、中歩数、高歩数）"""
 
 
-class EstimateSleepDFSchema(BaseTimeRangeValueDFSchema):
+class EstimateGoingOutDFSchema(BaseTimeRangeValueDFSchema):
     """睡眠状態を推定するためのDataFrameスキーマ"""
 
     steps_per_minute: Series[int] = pa.Field(nullable=False)

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, List
+from typing import Any, List, Tuple
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -22,6 +22,8 @@ def estimate_sleep_duration_from_step(
         charging_before_bed_answer (int): 就寝何時間前にスマホを充電するかの回答（0 ~ 4）
         carrying_a_smartphone_answer (int): の中でスマホを持ち歩くかの回答（0 ~ 2）
     """
+
+    print(late_night_list)
 
     # estimate_going_out_df の start_date とend_date カラムを文字列から日付型に変更
     estimate_going_out_df["start_date"] = pd.to_datetime(
@@ -65,9 +67,9 @@ def estimate_sleep_duration_from_step(
             ].sort_values("start_date")
 
             # 推定処理を実行
-            sleep_time_range = _late_night_estimate(day_df, time_range)
-
-            print(f"sleep_time_range:{sleep_time_range}")
+            sleep_time_range, is_default_time_list = _late_night_estimate(
+                day_df, time_range
+            )
 
         else:
             # 夜更かししていない場合の推定処理
@@ -79,24 +81,31 @@ def estimate_sleep_duration_from_step(
             ].sort_values("start_date")
 
             # 推定処理を実行
-            _normal_estimate(day_df, time_range)
+            sleep_time_range, is_default_time_list = _normal_estimate(
+                day_df, time_range
+            )
 
         # break
+
+        print(sleep_time_range, is_default_time_list)
 
     return
 
 
 def _late_night_estimate(
     day_df: DataFrame[EstimateGoingOutDFSchema], time_range: list[str]
-) -> List[Any]:
+) -> Tuple[List[Any], List[bool]]:
     """夜更かししている場合の推定処理\n
     0000->0300にレコードがあればそこを、なければ0300を精査開始時間とし、そこから2100までの歩数レコード間隔が最も長い時間を就寝/起床時刻とする。
 
     Args:
         day_df (DataFrame[EstimateGoingOutDFSchema]): 日々の歩数 DataFrame
         time_range (list[str]): 精査範囲
+
     Returns:
-        List[Any]: 日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+        Tuple[List[Any], List[bool]]:
+        日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+        デフォルトの時間を使ったかどうか [就寝時刻, 起床時刻]
     """
 
     # 精査するデータの時間範囲の指定
@@ -121,7 +130,10 @@ def _late_night_estimate(
 
     # データが無い場合は終了
     if filtered_df.empty:
-        return []
+        return [], []
+
+    # デフォルトの時間を使った場合に格納するリスト
+    is_default_time_list: List[bool] = []
 
     # 最大の睡眠時間と、その時の就寝・起床時刻を記録する変数
     max_sleep_duration = timedelta()
@@ -131,7 +143,7 @@ def _late_night_estimate(
     prev_start_time = start_time
 
     # その日の歩数データごとに処理を繰り返す
-    for row in filtered_df.itertuples():
+    for i, row in enumerate(filtered_df.itertuples()):
         # 現在のレコードの終了・開始時刻をそれぞれ間隔の開始・終了時刻とする取得
         current_start_time = row.end_date.time()
         current_end_time = row.start_date.time()
@@ -152,6 +164,11 @@ def _late_night_estimate(
             # 開始時刻と終了時刻を記録
             sleep_time_range = [prev_start_datetime.time(), current_end_datetime.time()]
 
+            if i == 0:
+                is_default_time_list = [True, False]
+            else:
+                is_default_time_list = [False, False]
+
         # 終了時刻を更新
         prev_start_time = current_start_time
 
@@ -159,14 +176,14 @@ def _late_night_estimate(
 
     # 睡眠時間が見つからなかった場合は空リストを返す
     if not sleep_time_range:
-        return []
+        return [], []
 
-    return sleep_time_range
+    return sleep_time_range, is_default_time_list
 
 
 def _normal_estimate(
     day_df: DataFrame[EstimateGoingOutDFSchema], time_range: List[str]
-) -> List[Any]:
+) -> Tuple[List[Any], List[bool]]:
     """夜更かししていない場合の推定処理\n
     2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝・起床時刻とする。
 
@@ -176,7 +193,9 @@ def _normal_estimate(
         time_range (list[str]): 精査範囲
 
     Returns:
-        List[Any]: 日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+        Tuple[List[Any], List[bool]]:
+        日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+        デフォルトの時間を使ったかどうか [就寝時刻, 起床時刻]
     """
 
     # 前日，当日の取得
@@ -184,7 +203,7 @@ def _normal_estimate(
 
     # データが無い場合は空の配列を返す
     if len(unique_dates) < 2:
-        return []
+        return [], []
 
     # 精査するデータの時間範囲の指定
     bed_end = pd.to_datetime(f"{time_range[0]}:00").time()
@@ -202,18 +221,25 @@ def _normal_estimate(
     wake_end_time = pd.Timestamp(f"{unique_dates[1].isoformat()} {wake_end}+09:00")
     wake_df = day_df[day_df["start_date"].between(wake_start_time, wake_end_time)]
 
+    # デフォルトの時間を使った場合に格納するリスト
+    is_default_time_list: List[bool] = []
+
+    print("normal sleep estimate")
+
     # 就寝時刻の推定
     if bed_df.empty:
         bed_time = bed_end
+        is_default_time_list.append(True)
     else:
         bed_time = bed_df["end_date"].max().time()
+        is_default_time_list.append(False)
 
     # 起床時刻の推定
     if wake_df.empty:
         wake_time = wake_start
+        is_default_time_list.append(True)
     else:
         wake_time = wake_df["start_date"].min().time()
+        is_default_time_list.append(False)
 
-    print([bed_time, wake_time])
-
-    return [bed_time, wake_time]
+    return [bed_time, wake_time], is_default_time_list

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -11,7 +11,7 @@ from src.core.constants import (
     WEEKDAY_TIME_RANGE,
 )
 from src.core.load_env import envs
-from src.schemas.estimate_sleep import EstimateGoingOutDFSchema
+from src.schemas.estimate_sleep import DailyEstimateSleep, EstimateGoingOutDFSchema
 
 
 def estimate_sleep_duration_from_step(
@@ -19,7 +19,7 @@ def estimate_sleep_duration_from_step(
     late_night_list: List[int],
     charging_before_bed_answer: int,
     carrying_a_smartphone_answer: int,
-):
+) -> List[DailyEstimateSleep]:
     """歩数から睡眠を推定する
 
     Args:
@@ -27,7 +27,13 @@ def estimate_sleep_duration_from_step(
         late_night_list (List[int]): 夜ふかし検知結果の配列
         charging_before_bed_answer (int): 就寝何時間前にスマホを充電するかの回答（0 ~ 4）
         carrying_a_smartphone_answer (int): の中でスマホを持ち歩くかの回答（0 ~ 2）
+
+    Returns:
+        List[DailyEstimateSleep]: 日々の推定睡眠データのリスト
     """
+
+    # 結果を格納するリスト
+    results: List[DailyEstimateSleep] = []
 
     print(late_night_list)
 
@@ -91,8 +97,6 @@ def estimate_sleep_duration_from_step(
                 day_df, time_range
             )
 
-        # break
-
         print(sleep_time_range, is_default_time_list)
 
         # 推定睡眠時間が空の場合
@@ -115,9 +119,17 @@ def estimate_sleep_duration_from_step(
             datetime.combine(datetime.today(), sleep_time_range[1]) - wake_time_cor
         )
 
-        print(f"最終時間：{corrected_bed_time.time(), corrected_wake_time.time()}")
+        # 結果リストに追加
+        results.append(
+            DailyEstimateSleep(
+                date=datetime.combine(date, datetime.min.time()),
+                bed_time=corrected_bed_time.strftime("%H:%M"),
+                wake_time=corrected_wake_time.strftime("%H:%M"),
+                is_default_time=is_default_time_list,
+            )
+        )
 
-    return
+    return results
 
 
 def _late_night_estimate(
@@ -288,7 +300,6 @@ def _get_correction_value(
         Tuple[pd.Timedelta, pd.Timedelta]:
         就寝時刻の補正値
         起床時刻の補正値
-
     """
 
     # 補正値データのパス

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -101,7 +101,14 @@ def estimate_sleep_duration_from_step(
 
         # 推定睡眠時間が空の場合
         if not sleep_time_range:
-            # 一旦 continue
+            results.append(
+                DailyEstimateSleep(
+                    date=date,
+                    bed_time="",
+                    wake_time="",
+                    is_default_time=is_default_time_list,
+                )
+            )
             continue
 
         # アンケート回答から補正値を取得
@@ -122,7 +129,7 @@ def estimate_sleep_duration_from_step(
         # 結果リストに追加
         results.append(
             DailyEstimateSleep(
-                date=datetime.combine(date, datetime.min.time()),
+                date=date,
                 bed_time=corrected_bed_time.strftime("%H:%M"),
                 wake_time=corrected_wake_time.strftime("%H:%M"),
                 is_default_time=is_default_time_list,

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -90,7 +90,14 @@ def _late_night_estimate(
     day_df: DataFrame[EstimateGoingOutDFSchema], time_range: list[str]
 ) -> List[Any]:
     """夜更かししている場合の推定処理\n
-    0000->0300にレコードがあればそこを、なければ0300を精査開始時間とし、そこから2100までの歩数レコード間隔が最も長い時間を就寝/起床時刻とする。"""
+    0000->0300にレコードがあればそこを、なければ0300を精査開始時間とし、そこから2100までの歩数レコード間隔が最も長い時間を就寝/起床時刻とする。
+
+    Args:
+        day_df (DataFrame[EstimateGoingOutDFSchema]): 日々の歩数 DataFrame
+        time_range (list[str]): 精査範囲
+    Returns:
+        List[Any]: 日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+    """
 
     # 精査するデータの時間範囲の指定
     initial_time = pd.to_datetime("00:00:00").time()
@@ -161,5 +168,4 @@ def _normal_estimate(
     2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝・起床時刻とする。"""
 
     print(f"time_range:{time_range}")
-    # print(day_df)
     return

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -155,6 +155,9 @@ def _late_night_estimate(
         # 終了時刻を更新
         prev_start_time = current_start_time
 
+        # TODO: 外出検知の場合はスキップ(1,2クラスタ)
+
+    # 睡眠時間が見つからなかった場合は空リストを返す
     if not sleep_time_range:
         return []
 
@@ -162,10 +165,55 @@ def _late_night_estimate(
 
 
 def _normal_estimate(
-    day_df: DataFrame[EstimateGoingOutDFSchema], time_range: list[str]
-):
+    day_df: DataFrame[EstimateGoingOutDFSchema], time_range: List[str]
+) -> List[Any]:
     """夜更かししていない場合の推定処理\n
-    2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝・起床時刻とする。"""
+    2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝・起床時刻とする。
 
-    print(f"time_range:{time_range}")
-    return
+
+    Args:
+        day_df (DataFrame[EstimateGoingOutDFSchema]): 日々の歩数 DataFrame
+        time_range (list[str]): 精査範囲
+
+    Returns:
+        List[Any]: 日々の推定睡眠時間範囲 [就寝時刻, 起床時刻]
+    """
+
+    # 前日，当日の取得
+    unique_dates = day_df["start_date"].dt.date.unique()
+
+    # データが無い場合は空の配列を返す
+    if len(unique_dates) < 2:
+        return []
+
+    # 精査するデータの時間範囲の指定
+    bed_end = pd.to_datetime(f"{time_range[0]}:00").time()
+    wake_start = pd.to_datetime(f"{time_range[1]}:00").time()
+    wake_end = pd.to_datetime(f"{time_range[2]}:00").time()
+    bed_start = pd.to_datetime(f"{time_range[3]}:00").time()
+
+    # 就寝時刻は前日から当日のデータを精査する
+    bed_start_time = pd.Timestamp(f"{unique_dates[0].isoformat()} {bed_start}+09:00")
+    bed_end_time = pd.Timestamp(f"{unique_dates[1].isoformat()} {bed_end}+09:00")
+    bed_df = day_df[day_df["start_date"].between(bed_start_time, bed_end_time)]
+
+    # 起床時刻は当日のデータから精査する
+    wake_start_time = pd.Timestamp(f"{unique_dates[1].isoformat()} {wake_start}+09:00")
+    wake_end_time = pd.Timestamp(f"{unique_dates[1].isoformat()} {wake_end}+09:00")
+    wake_df = day_df[day_df["start_date"].between(wake_start_time, wake_end_time)]
+
+    # 就寝時刻の推定
+    if bed_df.empty:
+        bed_time = bed_end
+    else:
+        bed_time = bed_df["end_date"].max().time()
+
+    # 起床時刻の推定
+    if wake_df.empty:
+        wake_time = wake_start
+    else:
+        wake_time = wake_df["start_date"].min().time()
+
+    print([bed_time, wake_time])
+
+    return [bed_time, wake_time]

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -1,8 +1,10 @@
+from datetime import datetime, timedelta
 from typing import List
 
 import pandas as pd
 from pandera.typing import DataFrame
 
+from src.core.constants import HOLIDAY_TIME_RANGE, WEEKDAY_TIME_RANGE
 from src.schemas.estimate_sleep import EstimateGoingOutDFSchema
 
 
@@ -12,7 +14,14 @@ def estimate_sleep_duration_from_step(
     charging_before_bed_answer: int,
     carrying_a_smartphone_answer: int,
 ):
-    """歩数から睡眠を推定する"""
+    """歩数から睡眠を推定する
+
+    Args:
+        estimate_going_out_df (DataFrame[EstimateGoingOutDFSchema]): クラスタリングのラベルを追加した DataFrame
+        late_night_list (List[int]): 夜ふかし検知結果の配列
+        charging_before_bed_answer (int): 就寝何時間前にスマホを充電するかの回答（0 ~ 4）
+        carrying_a_smartphone_answer (int): の中でスマホを持ち歩くかの回答（0 ~ 2）
+    """
 
     # estimate_going_out_df の start_date カラムを文字列から日付型に変更
     estimate_going_out_df["start_date"] = pd.to_datetime(
@@ -25,6 +34,43 @@ def estimate_sleep_duration_from_step(
         end=estimate_going_out_df["start_date"].iloc[-1].date(),
     ).date
 
-    print(unique_dates)
+    # 1日毎に抽出処理を繰り返す
+    for i, date in enumerate(unique_dates):
+        # 推定処理において前日を参照する関係上、レコードの最初の日はスキップする
+        if i == 0:
+            continue
+
+        # その日に夜更かしをしているかどうかを取得する
+        is_late_night: bool = bool(late_night_list[i])
+
+        # その日が平日かどうかを判定し、精査範囲を定義する
+        is_weekday: bool = date.weekday() < 5
+        if is_weekday:
+            time_range = WEEKDAY_TIME_RANGE
+        else:
+            time_range = HOLIDAY_TIME_RANGE
+
+        # 夜更かししているかどうかで推定方法が異なる
+        if is_late_night:
+            # 夜更かししている場合の推定処理
+
+            # その日の歩数データを取得
+            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[
+                (estimate_going_out_df["start_date"].dt.date == date)  # type: ignore
+            ].sort_values("start_date")
+
+        else:
+            # 夜更かししていない場合の推定処理
+
+            # その日と前日の歩数データを取得
+            target_dates: List[datetime] = [date - timedelta(days=1), date]
+            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[
+                estimate_going_out_df["start_date"].dt.date.isin(target_dates)  # type: ignore
+            ].sort_values("start_date")
+
+        print(f"time_range:{time_range}")
+        print(f"is_late_night:{is_late_night}")
+        print(day_df)
+        # break
 
     return

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -1,10 +1,16 @@
+import json
 from datetime import datetime, timedelta
 from typing import Any, List, Tuple
 
 import pandas as pd
 from pandera.typing import DataFrame
 
-from src.core.constants import HOLIDAY_TIME_RANGE, WEEKDAY_TIME_RANGE
+from src.core.constants import (
+    CORRECTION_VALUE_JSON_FILENAME,
+    HOLIDAY_TIME_RANGE,
+    WEEKDAY_TIME_RANGE,
+)
+from src.core.load_env import envs
 from src.schemas.estimate_sleep import EstimateGoingOutDFSchema
 
 
@@ -88,6 +94,28 @@ def estimate_sleep_duration_from_step(
         # break
 
         print(sleep_time_range, is_default_time_list)
+
+        # 推定睡眠時間が空の場合
+        if not sleep_time_range:
+            # 一旦 continue
+            continue
+
+        # アンケート回答から補正値を取得
+        bed_time_cor, wake_time_cor = _get_correction_value(
+            charging_before_bed_answer, carrying_a_smartphone_answer
+        )
+
+        print(bed_time_cor, wake_time_cor)
+
+        # 補正処理
+        corrected_bed_time = (
+            datetime.combine(datetime.today(), sleep_time_range[0]) + bed_time_cor
+        )
+        corrected_wake_time = (
+            datetime.combine(datetime.today(), sleep_time_range[1]) - wake_time_cor
+        )
+
+        print(f"最終時間：{corrected_bed_time.time(), corrected_wake_time.time()}")
 
     return
 
@@ -245,3 +273,43 @@ def _normal_estimate(
         is_default_time_list.append(False)
 
     return [bed_time, wake_time], is_default_time_list
+
+
+def _get_correction_value(
+    charging_before_bed_answer: int, carrying_a_smartphone_answer: int
+) -> Tuple[pd.Timedelta, pd.Timedelta]:
+    """回答から補正値を取得する
+
+    Args:
+        charging_before_bed_answer (int): 就寝何時間前にスマホを充電するかの回答（0 ~ 4）
+        carrying_a_smartphone_answer (int): の中でスマホを持ち歩くかの回答（0 ~ 2）
+
+    Returns:
+        Tuple[pd.Timedelta, pd.Timedelta]:
+        就寝時刻の補正値
+        起床時刻の補正値
+
+    """
+
+    # 補正値データのパス
+    path = f"/workspace/backend/{envs.STATISTICAL_DATA_DIR}/{CORRECTION_VALUE_JSON_FILENAME}"
+
+    # 補正値データの読み込み
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # 就寝時の補正値をリストに変換
+    bed_cor_list: List[int] = [int(value) for value in data["bed_cor"].values()]
+
+    # 起床時の補正値をリストに変換
+    wake_cor_list: List[int] = [int(value) for value in data["wake_cor"].values()]
+
+    # 選択した補正値を取得
+    bed_minutes: int = bed_cor_list[charging_before_bed_answer]
+    wake_minutes: int = wake_cor_list[carrying_a_smartphone_answer]
+
+    # 補正値を取得
+    bed_time_cor: pd.Timedelta = pd.to_timedelta(bed_minutes, unit="m")
+    wake_time_cor: pd.Timedelta = pd.to_timedelta(wake_minutes, unit="m")
+
+    return bed_time_cor, wake_time_cor

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -172,7 +172,9 @@ def _late_night_estimate(
         # 終了時刻を更新
         prev_start_time = current_start_time
 
-        # TODO: 外出検知の場合はスキップ(1,2クラスタ)
+        # 外出検知の場合はスキップ(1,2クラスタ)
+        if row.cluster_label in [1, 2]:
+            break
 
     # 睡眠時間が見つからなかった場合は空リストを返す
     if not sleep_time_range:

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -1,0 +1,30 @@
+from typing import List
+
+import pandas as pd
+from pandera.typing import DataFrame
+
+from src.schemas.estimate_sleep import EstimateGoingOutDFSchema
+
+
+def estimate_sleep_duration_from_step(
+    estimate_going_out_df: DataFrame[EstimateGoingOutDFSchema],
+    late_night_list: List[int],
+    charging_before_bed_answer: int,
+    carrying_a_smartphone_answer: int,
+):
+    """歩数から睡眠を推定する"""
+
+    # estimate_going_out_df の start_date カラムを文字列から日付型に変更
+    estimate_going_out_df["start_date"] = pd.to_datetime(
+        estimate_going_out_df["start_date"]
+    )
+
+    # Dataframe 内の全ての日付を抽出
+    unique_dates = pd.date_range(
+        start=estimate_going_out_df["start_date"].iloc[0].date(),
+        end=estimate_going_out_df["start_date"].iloc[-1].date(),
+    ).date
+
+    print(unique_dates)
+
+    return

--- a/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
+++ b/backend/src/usecases/estimate_sleep/estimate_sleep_duration_usecase.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List
+from typing import Any, List
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -23,9 +23,12 @@ def estimate_sleep_duration_from_step(
         carrying_a_smartphone_answer (int): の中でスマホを持ち歩くかの回答（0 ~ 2）
     """
 
-    # estimate_going_out_df の start_date カラムを文字列から日付型に変更
+    # estimate_going_out_df の start_date とend_date カラムを文字列から日付型に変更
     estimate_going_out_df["start_date"] = pd.to_datetime(
         estimate_going_out_df["start_date"]
+    )
+    estimate_going_out_df["end_date"] = pd.to_datetime(
+        estimate_going_out_df["end_date"]
     )
 
     # Dataframe 内の全ての日付を抽出
@@ -50,27 +53,113 @@ def estimate_sleep_duration_from_step(
         else:
             time_range = HOLIDAY_TIME_RANGE
 
+        print(f"{date}==============")
+
         # 夜更かししているかどうかで推定方法が異なる
         if is_late_night:
             # 夜更かししている場合の推定処理
 
-            # その日の歩数データを取得
-            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[
+            # その日の歩数データを start_date で整列して取得
+            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[  # type: ignore
                 (estimate_going_out_df["start_date"].dt.date == date)  # type: ignore
             ].sort_values("start_date")
+
+            # 推定処理を実行
+            sleep_time_range = _late_night_estimate(day_df, time_range)
+
+            print(f"sleep_time_range:{sleep_time_range}")
 
         else:
             # 夜更かししていない場合の推定処理
 
-            # その日と前日の歩数データを取得
+            # その日と前日の歩数データを start_date で整列して取得
             target_dates: List[datetime] = [date - timedelta(days=1), date]
-            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[
+            day_df: DataFrame[EstimateGoingOutDFSchema] = estimate_going_out_df[  # type: ignore
                 estimate_going_out_df["start_date"].dt.date.isin(target_dates)  # type: ignore
             ].sort_values("start_date")
 
-        print(f"time_range:{time_range}")
-        print(f"is_late_night:{is_late_night}")
-        print(day_df)
+            # 推定処理を実行
+            _normal_estimate(day_df, time_range)
+
         # break
 
+    return
+
+
+def _late_night_estimate(
+    day_df: DataFrame[EstimateGoingOutDFSchema], time_range: list[str]
+) -> List[Any]:
+    """夜更かししている場合の推定処理\n
+    0000->0300にレコードがあればそこを、なければ0300を精査開始時間とし、そこから2100までの歩数レコード間隔が最も長い時間を就寝/起床時刻とする。"""
+
+    # 精査するデータの時間範囲の指定
+    initial_time = pd.to_datetime("00:00:00").time()
+    start_time = pd.to_datetime(f"{time_range[0]}:00").time()
+    end_time = pd.to_datetime(f"{time_range[3]}:00").time()
+
+    # 精査初期値は、3時より前を見て最初に観測されたステップの end_date とする
+    # なければ3時を初期値とする
+    initial_time_df: DataFrame[EstimateGoingOutDFSchema] = day_df[
+        (day_df["end_date"].dt.time >= initial_time)
+        & (day_df["end_date"].dt.time <= start_time)
+    ]
+    if not initial_time_df.empty:
+        start_time = initial_time_df["end_date"].max().time()
+
+    # 精査範囲でデータを絞る
+    filtered_df: DataFrame[EstimateGoingOutDFSchema] = day_df[
+        (day_df["end_date"].dt.time >= start_time)
+        & (day_df["start_date"].dt.time <= end_time)
+    ]
+
+    # データが無い場合は終了
+    if filtered_df.empty:
+        return []
+
+    # 最大の睡眠時間と、その時の就寝・起床時刻を記録する変数
+    max_sleep_duration = timedelta()
+    sleep_time_range: List[Any] = []
+
+    # 前のレコードの終了時刻（初期時刻は精査開始時刻）
+    prev_start_time = start_time
+
+    # その日の歩数データごとに処理を繰り返す
+    for row in filtered_df.itertuples():
+        # 現在のレコードの終了・開始時刻をそれぞれ間隔の開始・終了時刻とする取得
+        current_start_time = row.end_date.time()
+        current_end_time = row.start_date.time()
+
+        # 終了時刻が初期開始時刻より小さい場合はスキップ（複数端末への対応）
+        if prev_start_time > current_end_time:
+            continue
+
+        # 前のレコードの終了時刻と現在のレコードの開始時刻の差（睡眠時間）を計算
+        prev_start_datetime = datetime.combine(datetime.today(), prev_start_time)
+        current_end_datetime = datetime.combine(datetime.today(), current_end_time)
+        sleep_duration = current_end_datetime - prev_start_datetime
+
+        # 現在の睡眠時間が最大より大きい場合は更新
+        if sleep_duration > max_sleep_duration:
+            max_sleep_duration = sleep_duration
+
+            # 開始時刻と終了時刻を記録
+            sleep_time_range = [prev_start_datetime.time(), current_end_datetime.time()]
+
+        # 終了時刻を更新
+        prev_start_time = current_start_time
+
+    if not sleep_time_range:
+        return []
+
+    return sleep_time_range
+
+
+def _normal_estimate(
+    day_df: DataFrame[EstimateGoingOutDFSchema], time_range: list[str]
+):
+    """夜更かししていない場合の推定処理\n
+    2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝・起床時刻とする。"""
+
+    print(f"time_range:{time_range}")
+    # print(day_df)
     return

--- a/backend/src/usecases/estimate_sleep/step_clustering_usecase.py
+++ b/backend/src/usecases/estimate_sleep/step_clustering_usecase.py
@@ -7,7 +7,7 @@ from sklearn.cluster import KMeans
 from src.core.constants import STEP_COUNT_CSV_FILENAME
 from src.core.load_env import envs
 from src.schemas.estimate_sleep import (
-    EstimateSleepDFSchema,
+    EstimateGoingOutDFSchema,
     StepClusterRecord,
     StepClusters,
 )
@@ -16,14 +16,14 @@ from src.schemas.extract_steps import StepCountDFSchema
 
 def step_clustering(
     step_count_df: DataFrame[StepCountDFSchema],
-) -> Tuple[DataFrame[EstimateSleepDFSchema], StepClusters]:
+) -> Tuple[DataFrame[EstimateGoingOutDFSchema], StepClusters]:
     """外出検知のため1分あたりの歩数を計算しクラスタリングを行う
 
     Args:
         step_count_df (DataFrame[StepCountDFSchema]): 歩数データの DataFrame
 
     Returns:
-        Tuple[DataFrame[EstimateSleepDFSchema], StepClusters]:
+        Tuple[DataFrame[EstimateGoingOutDFSchema], StepClusters]:
         クラスタリングのラベルを追加した DataFrame,
         クラスタリング結果のラベルとセントロイド
     """
@@ -87,10 +87,10 @@ def step_clustering(
     )  # type: ignore
 
     # 睡眠状態を推定するためのDataFrameを作成
-    estimate_sleep_df: DataFrame[EstimateSleepDFSchema] = step_count_df.copy()  # type: ignore
-    estimate_sleep_df["cluster_label"] = remapped_labels
+    estimate_going_out_df: DataFrame[EstimateGoingOutDFSchema] = step_count_df.copy()  # type: ignore
+    estimate_going_out_df["cluster_label"] = remapped_labels
 
-    return (estimate_sleep_df, StepClusters(clusters=cluster_stats))
+    return (estimate_going_out_df, StepClusters(clusters=cluster_stats))
 
 
 # デモ実行

--- a/backend/src/usecases/extract_steps/extract_steps_usecase.py
+++ b/backend/src/usecases/extract_steps/extract_steps_usecase.py
@@ -68,7 +68,7 @@ def extract_steps_from_applehealthcare(
         orient="records"
     )
 
-    # デバッグ用時は抽出したデータをCSVとして保存
+    # デバッグ時は抽出したデータをCSVとして保存
     if envs.IS_DEBUG:
         if step_count_df is not None:
             step_count_df.to_csv(


### PR DESCRIPTION
# 概要

睡眠推定処理

## 実施した内容

#### 歩数から睡眠期間を推定
：夜更かしした日とそうでない日で異なる睡眠期間の推定を行う

夜ふかししていない日：2500->2100、0415->1200を遡って最初に観測された歩数レコードを就寝/起床時刻とする。
夜ふかししている日：0000->0300にレコードがあればそこを、なければ0300を精査開始時間とし、そこから2100までの歩数レコード間隔が最も長い時間を就寝/起床時刻とする。その際、その歩数レコードが外出している場合は処理を中断する。
最後に得られた時刻からアンケートによる時間補正を行う。

#### デバッグ時にのみ print を動作させる

#### リントエラーの整理

## チェックリスト

<!-- 提出前にすべての項目が完了していることを確認してください -->

- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] セルフレビューを完了
- [x] 複雑なコードにコメントを追加
- [x] ドキュメントを更新（該当する場合）
- [x] 破壊的変更なし（またはやむを得ない場合は文書化済み）
- [x] ci / cd を通過

## 備考

## 関連 Issue

<!-- #issue_number を使用して関連するIssueをリンクしてください -->

Closes #3 
